### PR TITLE
Rework shaders and rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,9 +71,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.94"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
+checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
 
 [[package]]
 name = "log"

--- a/koala_chess/src/board.rs
+++ b/koala_chess/src/board.rs
@@ -1,14 +1,13 @@
-use crate::shader::Shader;
 use crate::{
     bitmap,
     mat4::Mat4,
-    transformations::{rotate_z, translate},
+    shader::Shader,
+    traits::Draw,
+    transformations::{rotate_z, scale, translate},
     vec3::Vec3,
 };
-use crate::{traits::Draw, transformations::scale};
 use logger::*;
-use std::sync::Mutex;
-use std::{error::Error, lazy::SyncLazy};
+use std::{error::Error, lazy::SyncLazy, sync::Mutex};
 
 static SHADER: SyncLazy<Mutex<Option<Shader>>> = SyncLazy::new(|| Mutex::new(None));
 static mut VERTEX_BUFFER_OBJECT: gl::types::GLuint = 0;

--- a/koala_chess/src/board.rs
+++ b/koala_chess/src/board.rs
@@ -28,11 +28,11 @@ impl Board {
 
         #[rustfmt::skip]
         let vertices: [f32; 16] = [
-             // positions, texture coordinates
-             1.0, 0.0,     1.0, 0.0, // top right
-             1.0, 1.0,     1.0, 1.0, // bottom right
-             0.0, 1.0,     0.0, 1.0, // bottom left
-             0.0, 0.0,     0.0, 0.0, // top left
+            // positions, texture coordinates
+            1.0, 0.0,     1.0, 0.0, // top right
+            1.0, 1.0,     1.0, 1.0, // bottom right
+            0.0, 1.0,     0.0, 1.0, // bottom left
+            0.0, 0.0,     0.0, 0.0, // top left
         ];
 
         unsafe {

--- a/koala_chess/src/board.rs
+++ b/koala_chess/src/board.rs
@@ -131,13 +131,13 @@ impl Draw for Board {
         shader.r#use();
 
         let mut translation = Vec3::default();
-        translation[0] = 200.0;
-        translation[1] = 200.0;
+        translation[0] = 90.0;
+        translation[1] = 80.0;
 
         let mut model = Mat4::identity();
         model = translate(model, translation);
-        model = rotate_z(model, 45.0);
-        model = scale(model, Vec3::new(400.0));
+        model = rotate_z(model, 0.0);
+        model = scale(model, Vec3::new(620.0));
         let projection = orthogonal_projection(0.0, 800.0, 800.0, 0.0, -1.0, 1.0);
 
         shader.set_mat4("model\0", model.data.as_ptr() as *const gl::types::GLfloat)?;

--- a/koala_chess/src/board.rs
+++ b/koala_chess/src/board.rs
@@ -29,10 +29,10 @@ impl Board {
         #[rustfmt::skip]
         let vertices: [f32; 16] = [
             // positions, texture coordinates
+            0.0, 0.0,     0.0, 0.0, // top left
             1.0, 0.0,     1.0, 0.0, // top right
             1.0, 1.0,     1.0, 1.0, // bottom right
             0.0, 1.0,     0.0, 1.0, // bottom left
-            0.0, 0.0,     0.0, 0.0, // top left
         ];
 
         unsafe {
@@ -139,8 +139,6 @@ impl Draw for Board {
             bottom /= aspect_ratio;
         }
 
-        let projection = orthogonal_projection(0.0, right, bottom, 0.0, -1.0, 1.0);
-
         let board_size = 620.0;
 
         // Calculate centering translation
@@ -153,10 +151,12 @@ impl Draw for Board {
         model = rotate_z(model, 0.0);
         model = scale(model, Vec3::new(board_size));
 
+        let projection = orthogonal_projection(0.0, right, bottom, 0.0, -1.0, 1.0);
+
         shader.set_mat4("model\0", model.data.as_ptr() as *const gl::types::GLfloat)?;
         shader.set_mat4(
             "projection\0",
-            projection.as_ptr() as *const gl::types::GLfloat,
+            projection.data.as_ptr() as *const gl::types::GLfloat,
         )?;
 
         // Draw elements
@@ -176,9 +176,8 @@ fn orthogonal_projection(
     top: gl::types::GLfloat,
     near: gl::types::GLfloat,
     far: gl::types::GLfloat,
-) -> [[gl::types::GLfloat; 4]; 4] {
-    // right handed, -1 to 1
-    let mut projection: [[gl::types::GLfloat; 4]; 4] = [[0.0; 4]; 4];
+) -> Mat4 {
+    let mut projection = Mat4::default();
     projection[0][0] = 2.0 / (right - left);
     projection[1][1] = 2.0 / (top - bottom);
     projection[2][2] = -2.0 / (far - near);
@@ -189,27 +188,4 @@ fn orthogonal_projection(
     projection[3][3] = 1.0;
 
     projection
-}
-
-// Left-handed, 0 to 1
-fn _orthogonal_projection_lh_zo(
-    left: gl::types::GLfloat,
-    right: gl::types::GLfloat,
-    bottom: gl::types::GLfloat,
-    top: gl::types::GLfloat,
-    near: gl::types::GLfloat,
-    far: gl::types::GLfloat,
-) -> *const gl::types::GLfloat {
-    // left handed, 0 to 1
-    let mut projection: [[gl::types::GLfloat; 4]; 4] = [[0.0; 4]; 4];
-    projection[0][0] = 2.0 / (right - left);
-    projection[1][1] = 2.0 / (top - bottom);
-    projection[2][2] = 1.0 / (far - near);
-    projection[3][0] = -(right + left) / (right - left);
-    projection[3][1] = -(top + bottom) / (top - bottom);
-    projection[3][2] = -near / (far - near);
-
-    projection[3][3] = 1.0;
-
-    projection.as_ptr() as *const gl::types::GLfloat
 }

--- a/koala_chess/src/board.rs
+++ b/koala_chess/src/board.rs
@@ -130,22 +130,34 @@ impl Draw for Board {
         let shader = shader_mutex.unwrap_or_else(|| fatal!("Shader has not been initialized yet!"));
         shader.r#use();
 
+        let mut right = 800.0;
+        let mut bottom = 800.0;
+
+        if aspect_ratio >= 1.0 {
+            right *= aspect_ratio;
+        } else {
+            bottom /= aspect_ratio;
+        }
+
+        let projection = orthogonal_projection(0.0, right, bottom, 0.0, -1.0, 1.0);
+
+        let board_size = 620.0;
+
+        // Calculate centering translation
         let mut translation = Vec3::default();
-        translation[0] = 90.0;
-        translation[1] = 80.0;
+        translation[0] = right / 2.0 - board_size / 2.0;
+        translation[1] = bottom / 2.0 - board_size / 2.0;
 
         let mut model = Mat4::identity();
         model = translate(model, translation);
         model = rotate_z(model, 0.0);
-        model = scale(model, Vec3::new(620.0));
-        let projection = orthogonal_projection(0.0, 800.0, 800.0, 0.0, -1.0, 1.0);
+        model = scale(model, Vec3::new(board_size));
 
         shader.set_mat4("model\0", model.data.as_ptr() as *const gl::types::GLfloat)?;
         shader.set_mat4(
             "projection\0",
             projection.as_ptr() as *const gl::types::GLfloat,
         )?;
-        // shader.set_float("aspect_ratio\0", aspect_ratio)?;
 
         // Draw elements
         unsafe {

--- a/koala_chess/src/game.rs
+++ b/koala_chess/src/game.rs
@@ -1,6 +1,9 @@
-use crate::piece::{Piece, PieceColor, PieceKind};
-use crate::traits::Draw;
-use crate::{board::Board, shader};
+use crate::{
+    board::Board,
+    piece::{Piece, PieceColor, PieceKind},
+    shader,
+    traits::Draw,
+};
 use logger::*;
 use std::error::Error;
 

--- a/koala_chess/src/game.rs
+++ b/koala_chess/src/game.rs
@@ -145,7 +145,7 @@ impl Draw for Game {
 
         // Draw pieces
         for piece in self.pieces.iter() {
-            // piece.draw(aspect_ratio)?;
+            piece.draw(aspect_ratio)?;
         }
 
         Ok(())

--- a/koala_chess/src/game.rs
+++ b/koala_chess/src/game.rs
@@ -145,7 +145,7 @@ impl Draw for Game {
 
         // Draw pieces
         for piece in self.pieces.iter() {
-            piece.draw(aspect_ratio)?;
+            // piece.draw(aspect_ratio)?;
         }
 
         Ok(())

--- a/koala_chess/src/main.rs
+++ b/koala_chess/src/main.rs
@@ -4,11 +4,15 @@
 mod bitmap;
 mod board;
 mod game;
+mod mat4;
 mod piece;
 mod platform;
 mod renderer;
 mod shader;
 mod traits;
+mod transformations;
+mod vec3;
+mod vec4;
 
 use game::Game;
 

--- a/koala_chess/src/mat4.rs
+++ b/koala_chess/src/mat4.rs
@@ -1,0 +1,36 @@
+use crate::vec4::Vec4;
+use std::ops::{Index, IndexMut};
+
+#[derive(Default)]
+pub struct Mat4 {
+    // data[column][row]
+    pub data: [Vec4; 4],
+}
+
+impl Index<usize> for Mat4 {
+    type Output = Vec4;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        // Return a specific column
+        &self.data[index]
+    }
+}
+
+impl IndexMut<usize> for Mat4 {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        // Return a specific column
+        &mut self.data[index]
+    }
+}
+
+impl Mat4 {
+    pub fn identity() -> Mat4 {
+        let mut result = Mat4::default();
+        result[0][0] = 1.0;
+        result[1][1] = 1.0;
+        result[2][2] = 1.0;
+        result[3][3] = 1.0;
+
+        result
+    }
+}

--- a/koala_chess/src/piece.rs
+++ b/koala_chess/src/piece.rs
@@ -1,13 +1,13 @@
-use crate::bitmap;
-use crate::mat4::Mat4;
-use crate::shader::Shader;
-use crate::traits::Draw;
-use crate::transformations::scale;
-use crate::transformations::translate;
-use crate::vec3::Vec3;
+use crate::{
+    bitmap,
+    mat4::Mat4,
+    shader::Shader,
+    traits::Draw,
+    transformations::{scale, translate},
+    vec3::Vec3,
+};
 use logger::*;
-use std::sync::Mutex;
-use std::{error::Error, lazy::SyncLazy};
+use std::{error::Error, lazy::SyncLazy, sync::Mutex};
 
 pub enum PieceColor {
     White,

--- a/koala_chess/src/piece.rs
+++ b/koala_chess/src/piece.rs
@@ -70,12 +70,12 @@ impl Piece {
             .unwrap_or_else(|e| fatal!("Could not load pieces bitmap! ({})", e));
 
         #[rustfmt::skip]
-        let vertices: [f32; 32] = [
-            // positions,    colors,        texture coordinates
-             1.0,  1.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, // top right
-             1.0, -1.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0, // bottom right
-            -1.0, -1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, // bottom left
-            -1.0,  1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, // top left
+        let vertices: [f32; 16] = [
+            // positions, texture coordinates
+            1.0, 0.0,     1.0, 0.0, // top right
+            1.0, 1.0,     1.0, 1.0, // bottom right
+            0.0, 1.0,     0.0, 1.0, // bottom left
+            0.0, 0.0,     0.0, 0.0, // top left
         ];
 
         unsafe {
@@ -150,35 +150,17 @@ impl Draw for Piece {
             // Position attribute
             gl::VertexAttribPointer(
                 0,
-                3,
+                2,
                 gl::FLOAT,
                 gl::FALSE,
-                32,
+                16,
                 std::ptr::null::<std::ffi::c_void>(),
             );
             gl::EnableVertexAttribArray(0);
 
-            // Color attribute
-            gl::VertexAttribPointer(
-                1,
-                3,
-                gl::FLOAT,
-                gl::FALSE,
-                32,
-                12 as *const std::ffi::c_void,
-            );
-            gl::EnableVertexAttribArray(1);
-
             // Texture coordinates attribute
-            gl::VertexAttribPointer(
-                2,
-                2,
-                gl::FLOAT,
-                gl::FALSE,
-                32,
-                24 as *const std::ffi::c_void,
-            );
-            gl::EnableVertexAttribArray(2);
+            gl::VertexAttribPointer(1, 2, gl::FLOAT, gl::FALSE, 16, 8 as *const std::ffi::c_void);
+            gl::EnableVertexAttribArray(1);
 
             // Bind texture
             gl::BindTexture(gl::TEXTURE_2D, TEXTURE);

--- a/koala_chess/src/platform/windows.rs
+++ b/koala_chess/src/platform/windows.rs
@@ -93,8 +93,8 @@ pub fn create_window() -> HWND {
             WS_OVERLAPPEDWINDOW | WS_VISIBLE, // dwStyle
             CW_USEDEFAULT,                    // X
             CW_USEDEFAULT,                    // Y
-            CW_USEDEFAULT,                    // nWidth
-            CW_USEDEFAULT,                    // nHeight
+            800,                              //CW_USEDEFAULT,                    // nWidth
+            800,                              //CW_USEDEFAULT,                    // nHeight
             std::ptr::null_mut(),             // hWndParent
             std::ptr::null_mut(),             // hMenu
             window_class.hInstance,           // hInstance

--- a/koala_chess/src/platform/windows.rs
+++ b/koala_chess/src/platform/windows.rs
@@ -93,8 +93,8 @@ pub fn create_window() -> HWND {
             WS_OVERLAPPEDWINDOW | WS_VISIBLE, // dwStyle
             CW_USEDEFAULT,                    // X
             CW_USEDEFAULT,                    // Y
-            800,                              //CW_USEDEFAULT,                    // nWidth
-            800,                              //CW_USEDEFAULT,                    // nHeight
+            CW_USEDEFAULT,                    // nWidth
+            CW_USEDEFAULT,                    // nHeight
             std::ptr::null_mut(),             // hWndParent
             std::ptr::null_mut(),             // hMenu
             window_class.hInstance,           // hInstance

--- a/koala_chess/src/renderer/open_gl.rs
+++ b/koala_chess/src/renderer/open_gl.rs
@@ -36,6 +36,7 @@ pub fn initialize_open_gl_addresses(get_open_gl_address: fn(&str) -> *const std:
     let _ = gl::LinkProgram::load_with(|function_name| get_open_gl_address(function_name));
     let _ = gl::ShaderSource::load_with(|function_name| get_open_gl_address(function_name));
     let _ = gl::Uniform1f::load_with(|function_name| get_open_gl_address(function_name));
+    let _ = gl::UniformMatrix4fv::load_with(|function_name| get_open_gl_address(function_name));
     let _ = gl::UseProgram::load_with(|function_name| get_open_gl_address(function_name));
     let _ = gl::VertexAttribPointer::load_with(|function_name| get_open_gl_address(function_name));
 }

--- a/koala_chess/src/shader.rs
+++ b/koala_chess/src/shader.rs
@@ -89,6 +89,26 @@ impl Shader {
 
         Ok(())
     }
+
+    pub fn set_mat4(
+        &self,
+        name: &str,
+        value: *const gl::types::GLfloat,
+    ) -> Result<(), Box<dyn Error>> {
+        let uniform_location = unsafe {
+            gl::GetUniformLocation(self.program, name.as_ptr() as *const gl::types::GLchar)
+        };
+
+        if uniform_location == -1 {
+            return Err(format!("Could not get uniform location! (name: {})", name).into());
+        }
+
+        unsafe {
+            gl::UniformMatrix4fv(uniform_location, 1, gl::FALSE, value);
+        }
+
+        Ok(())
+    }
 }
 
 fn check_for_shader_errors(

--- a/koala_chess/src/transformations.rs
+++ b/koala_chess/src/transformations.rs
@@ -1,0 +1,109 @@
+use crate::{mat4::Mat4, vec3::Vec3};
+
+pub fn translate(matrix: Mat4, vector: Vec3) -> Mat4 {
+    let mut result = Mat4::default();
+    result[0] = matrix[0]; // keep 1st column
+    result[1] = matrix[1]; // keep 2nd column
+    result[2] = matrix[2]; // keep 3rd column
+    result[3] = matrix[0] * vector[0] + matrix[1] * vector[1] + matrix[2] * vector[2] + matrix[3]; // calculate 4th column
+
+    /*
+    Example (2D):
+
+    Identity matrix:
+
+    (1 0 0 0)
+    (0 1 0 0)
+    (0 0 1 0)
+    (0 0 0 1)
+
+    Vector:
+
+    (5)
+    (5)
+    (0)
+
+    Results in:
+
+    (1 0 0 5)
+    (0 1 0 5)
+    (0 0 1 0)
+    (0 0 0 1)
+    */
+
+    result
+}
+
+pub fn rotate_z(matrix: Mat4, angle_in_degrees: gl::types::GLfloat) -> Mat4 {
+    let sin = angle_in_degrees.to_radians().sin();
+    let cos = angle_in_degrees.to_radians().cos();
+
+    let mut result = Mat4::default();
+    result[0] = matrix[0];
+    result[1] = matrix[1];
+    result[2] = matrix[2]; // keep 3rd column
+    result[3] = matrix[3]; // keep 4th column
+
+    result[0][0] = cos;
+    result[0][1] = sin;
+    result[1][0] = -sin;
+    result[1][1] = cos;
+
+    /*
+    Example (2D):
+
+    Identity matrix:
+
+    (1 0 0 0)
+    (0 1 0 0)
+    (0 0 1 0)
+    (0 0 0 1)
+
+    Angle (in degrees):
+
+    45°
+
+    Results in:
+
+    (cos(rad(45)) -sin(rad(45)) 0 0)
+    (sin(rad(45)) cos(rad(45))  0 0)
+    (0            0             1 0)
+    (0            0             0 1)
+    */
+
+    result
+}
+
+pub fn scale(matrix: Mat4, vector: Vec3) -> Mat4 {
+    let mut result = Mat4::default();
+    result[0] = matrix[0] * vector[0]; // multiply 1st column
+    result[1] = matrix[1] * vector[1]; // multiply 2nd column
+    result[2] = matrix[2] * vector[2]; // multiply 3rd column
+    result[3] = matrix[3]; // keep 4th column
+
+    /*
+    Example (2D):
+
+    Identity matrix:
+
+    (1 0 0 0)
+    (0 1 0 0)
+    (0 0 1 0)
+    (0 0 0 1)
+
+    Vector:
+
+    (5)
+    (5)
+    (1)
+
+    Results in:
+
+    (5 0 0 0)
+    (0 5 0 0)
+    (0 0 1 0)
+    (0 0 0 1)
+    */
+
+    result
+}

--- a/koala_chess/src/vec3.rs
+++ b/koala_chess/src/vec3.rs
@@ -26,10 +26,10 @@ impl Add<Vec3> for Vec3 {
     type Output = Vec3;
 
     fn add(self, rhs: Vec3) -> Self::Output {
-        let mut result = self.clone();
-        result[0] = result[0] + rhs[0];
-        result[1] = result[1] + rhs[1];
-        result[2] = result[2] + rhs[2];
+        let mut result = self;
+        result[0] += rhs[0];
+        result[1] += rhs[1];
+        result[2] += rhs[2];
 
         result
     }
@@ -39,10 +39,10 @@ impl Mul<gl::types::GLfloat> for Vec3 {
     type Output = Vec3;
 
     fn mul(self, rhs: gl::types::GLfloat) -> Self::Output {
-        let mut result = self.clone();
-        result[0] = result[0] * rhs;
-        result[1] = result[1] * rhs;
-        result[2] = result[2] * rhs;
+        let mut result = self;
+        result[0] *= rhs;
+        result[1] *= rhs;
+        result[2] *= rhs;
 
         result
     }

--- a/koala_chess/src/vec3.rs
+++ b/koala_chess/src/vec3.rs
@@ -1,0 +1,60 @@
+use std::ops::{Add, Index, IndexMut, Mul};
+
+#[derive(Default, Clone, Copy)]
+pub struct Vec3 {
+    // data
+    data: [gl::types::GLfloat; 3],
+}
+
+impl Index<usize> for Vec3 {
+    type Output = gl::types::GLfloat;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        // Return a specific element
+        &self.data[index]
+    }
+}
+
+impl IndexMut<usize> for Vec3 {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        // Return a specific element
+        &mut self.data[index]
+    }
+}
+
+impl Add<Vec3> for Vec3 {
+    type Output = Vec3;
+
+    fn add(self, rhs: Vec3) -> Self::Output {
+        let mut result = self.clone();
+        result[0] = result[0] + rhs[0];
+        result[1] = result[1] + rhs[1];
+        result[2] = result[2] + rhs[2];
+
+        result
+    }
+}
+
+impl Mul<gl::types::GLfloat> for Vec3 {
+    type Output = Vec3;
+
+    fn mul(self, rhs: gl::types::GLfloat) -> Self::Output {
+        let mut result = self.clone();
+        result[0] = result[0] * rhs;
+        result[1] = result[1] * rhs;
+        result[2] = result[2] * rhs;
+
+        result
+    }
+}
+
+impl Vec3 {
+    pub fn new(value: gl::types::GLfloat) -> Vec3 {
+        let mut result = Vec3::default();
+        result[0] = value;
+        result[1] = value;
+        result[2] = value;
+
+        result
+    }
+}

--- a/koala_chess/src/vec4.rs
+++ b/koala_chess/src/vec4.rs
@@ -26,11 +26,11 @@ impl Add<Vec4> for Vec4 {
     type Output = Vec4;
 
     fn add(self, rhs: Vec4) -> Self::Output {
-        let mut result = self.clone();
-        result[0] = result[0] + rhs[0];
-        result[1] = result[1] + rhs[1];
-        result[2] = result[2] + rhs[2];
-        result[3] = result[3] + rhs[3];
+        let mut result = self;
+        result[0] += rhs[0];
+        result[1] += rhs[1];
+        result[2] += rhs[2];
+        result[3] += rhs[3];
 
         result
     }
@@ -40,18 +40,18 @@ impl Mul<gl::types::GLfloat> for Vec4 {
     type Output = Vec4;
 
     fn mul(self, rhs: gl::types::GLfloat) -> Self::Output {
-        let mut result = self.clone();
-        result[0] = result[0] * rhs;
-        result[1] = result[1] * rhs;
-        result[2] = result[2] * rhs;
-        result[3] = result[3] * rhs;
+        let mut result = self;
+        result[0] *= rhs;
+        result[1] *= rhs;
+        result[2] *= rhs;
+        result[3] *= rhs;
 
         result
     }
 }
 
 impl Vec4 {
-    pub fn new(value: gl::types::GLfloat) -> Vec4 {
+    pub fn _new(value: gl::types::GLfloat) -> Vec4 {
         let mut result = Vec4::default();
         result[0] = value;
         result[1] = value;

--- a/koala_chess/src/vec4.rs
+++ b/koala_chess/src/vec4.rs
@@ -1,0 +1,63 @@
+use std::ops::{Add, Index, IndexMut, Mul};
+
+#[derive(Default, Clone, Copy)]
+pub struct Vec4 {
+    // data
+    data: [gl::types::GLfloat; 4],
+}
+
+impl Index<usize> for Vec4 {
+    type Output = gl::types::GLfloat;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        // Return a specific element
+        &self.data[index]
+    }
+}
+
+impl IndexMut<usize> for Vec4 {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        // Return a specific element
+        &mut self.data[index]
+    }
+}
+
+impl Add<Vec4> for Vec4 {
+    type Output = Vec4;
+
+    fn add(self, rhs: Vec4) -> Self::Output {
+        let mut result = self.clone();
+        result[0] = result[0] + rhs[0];
+        result[1] = result[1] + rhs[1];
+        result[2] = result[2] + rhs[2];
+        result[3] = result[3] + rhs[3];
+
+        result
+    }
+}
+
+impl Mul<gl::types::GLfloat> for Vec4 {
+    type Output = Vec4;
+
+    fn mul(self, rhs: gl::types::GLfloat) -> Self::Output {
+        let mut result = self.clone();
+        result[0] = result[0] * rhs;
+        result[1] = result[1] * rhs;
+        result[2] = result[2] * rhs;
+        result[3] = result[3] * rhs;
+
+        result
+    }
+}
+
+impl Vec4 {
+    pub fn new(value: gl::types::GLfloat) -> Vec4 {
+        let mut result = Vec4::default();
+        result[0] = value;
+        result[1] = value;
+        result[2] = value;
+        result[3] = value;
+
+        result
+    }
+}

--- a/shaders/atlas.vert
+++ b/shaders/atlas.vert
@@ -2,9 +2,8 @@
 #define M_PI 3.1415926535897932384626433832795
 precision mediump float;
 
-layout (location = 0) in vec3 in_position;
-layout (location = 1) in vec3 in_color;
-layout (location = 2) in vec2 in_texture_coordinate;
+layout (location = 0) in vec2 in_position;
+layout (location = 1) in vec2 in_texture_coordinate;
 
 uniform float board_x;
 uniform float board_y;
@@ -66,7 +65,6 @@ void main()
         rotated_y *= aspect_ratio;
     }
 
-    gl_Position = vec4(vec3(rotated_x, rotated_y, in_position.z), 1.0);
-    color = in_color;
+    gl_Position = vec4(rotated_x, rotated_y, 0.0, 1.0);
     texture_coordinate = in_texture_coordinate;
 }

--- a/shaders/atlas.vert
+++ b/shaders/atlas.vert
@@ -1,70 +1,21 @@
 #version 300 es
-#define M_PI 3.1415926535897932384626433832795
 precision mediump float;
 
 layout (location = 0) in vec2 in_position;
 layout (location = 1) in vec2 in_texture_coordinate;
 
-uniform float board_x;
-uniform float board_y;
-uniform float rotation;
-uniform float aspect_ratio;
+uniform mat4 model;
+uniform mat4 projection;
 
-out vec3 color;
 out vec2 texture_coordinate;
-
-const float texture_size = 1024.0;
-const float border_size = 6.0;
-const float margin = 0.2;
-const float tile_count = 8.0;
-const float tile_offset = -7.0;
-
-// (1024.0 - 2.0 * 6.0) * (1.0 - 0.2) / 8.0
-// (1024.0 - 12.0) * 0.8 / 8.0
-// 1012.0 * 0.8 / 8.0
-// 101.2
-const float tile_size = (texture_size - 2.0 * border_size) * (1.0 - margin) / tile_count;
-
-// 101.2 / 1024.0
-// 0.098828125
-const float scale = tile_size / texture_size;
 
 void main()
 {
-    // Map each board coordinate from [0,7] to [-7,7]
-    // (0,0) => (-7,-7)
-    // (1,0) => (-5,-7)
-    // ...
-    // (7,0) => ( 7, 0)
-    float corrected_board_x = board_x * 2.0 + tile_offset;
-    float corrected_board_y = board_y * 2.0 + tile_offset;
-
-    // Scaling
-    float scaled_x = (in_position.x + corrected_board_x) * scale;
-    float scaled_y = (in_position.y + corrected_board_y) * scale;
-
-    // Rotation
-    float rotated_x = scaled_x;
-    float rotated_y = scaled_y;
-
-    if (rotation > 0.0)
-    {
-        float radian = rotation * (M_PI / 180.0);
-
-        rotated_x = cos(radian) * scaled_x - sin(radian) * scaled_y;
-        rotated_y = sin(radian) * scaled_x + cos(radian) * scaled_y;
-    }
-
-    // Aspect ratio
-    if (aspect_ratio >= 1.0)
-    {
-        rotated_x /= aspect_ratio;
-    }
-    else
-    {
-        rotated_y *= aspect_ratio;
-    }
-
-    gl_Position = vec4(rotated_x, rotated_y, 0.0, 1.0);
+    gl_Position = projection * model * vec4(
+        in_position.x,
+        // OpenGL expects 0.0 to be at the bottom, but 0.0 is at the top for the texture
+        1.0 - in_position.y,
+        0.0,
+        1.0);
     texture_coordinate = in_texture_coordinate;
 }

--- a/shaders/fragment.frag
+++ b/shaders/fragment.frag
@@ -1,7 +1,6 @@
 #version 300 es
 precision mediump float;
 
-in vec3 color;
 in vec2 texture_coordinate;
 
 uniform sampler2D uniform_texture;

--- a/shaders/vertex.vert
+++ b/shaders/vertex.vert
@@ -1,45 +1,16 @@
 #version 300 es
-#define M_PI 3.1415926535897932384626433832795
 precision mediump float;
 
-layout (location = 0) in vec3 in_position;
-layout (location = 1) in vec3 in_color;
-layout (location = 2) in vec2 in_texture_coordinate;
+layout (location = 0) in vec2 in_position;
+layout (location = 1) in vec2 in_texture_coordinate;
 
-uniform float rotation;
-uniform float aspect_ratio;
+uniform mat4 model;
+uniform mat4 projection;
 
-out vec3 color;
 out vec2 texture_coordinate;
 
 void main()
 {
-    float initial_x = in_position.x;
-    float initial_y = in_position.y;
-
-    // Rotation
-    float rotated_x = initial_x;
-    float rotated_y = initial_y;
-
-    if (rotation > 0.0)
-    {
-        float radian = rotation * (M_PI / 180.0);
-
-        rotated_x = cos(radian) * initial_x - sin(radian) * initial_y;
-        rotated_y = sin(radian) * initial_x + cos(radian) * initial_y;
-    }
-
-    // Aspect ratio
-    if (aspect_ratio >= 1.0)
-    {
-        rotated_x /= aspect_ratio;
-    }
-    else
-    {
-        rotated_y *= aspect_ratio;
-    }
-
-    gl_Position = vec4(vec3(rotated_x, rotated_y, in_position.z), 1.0);
-    color = in_color;
+    gl_Position = projection * model * vec4(in_position.xy, 0.0, 1.0);
     texture_coordinate = in_texture_coordinate;
 }

--- a/shaders/vertex.vert
+++ b/shaders/vertex.vert
@@ -11,6 +11,11 @@ out vec2 texture_coordinate;
 
 void main()
 {
-    gl_Position = projection * model * vec4(in_position.xy, 0.0, 1.0);
+    gl_Position = projection * model * vec4(
+        in_position.x,
+        // OpenGL expects 0.0 to be at the bottom, but 0.0 is at the top for the texture
+        1.0 - in_position.y,
+        0.0,
+        1.0);
     texture_coordinate = in_texture_coordinate;
 }


### PR DESCRIPTION
- Adds orthographic projection
- Adds `mat4` (4x4 matrix), `vec3` and `vec4` data structure
  - Including identity matrix and necessary operators
- Adds `mat4` operations like `translate`, `rotate` and `scale`
- Adjusts shader implementations where we performed translations, rotations and scaling
- Adjust atlas shader implementations where we performed translations, rotations and scaling