### PR TITLE
Rework rendering flow and be able to rotate board and pieces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,9 +71,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.97"
+version = "0.2.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
+checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 
 [[package]]
 name = "log"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,9 +71,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
+checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
 
 [[package]]
 name = "log"

--- a/koala_chess/src/board.rs
+++ b/koala_chess/src/board.rs
@@ -140,7 +140,12 @@ impl Board {
         model = translate(model, Vec3::new_xyz(self.x, self.y, 0.0));
 
         if self.rotation != 0.0 {
+            let x_translation = self.width / 2.0;
+            let y_translation = self.height / 2.0;
+
+            model = translate(model, Vec3::new_xyz(x_translation, y_translation, 0.0));
             model = rotate_z(model, self.rotation);
+            model = translate(model, Vec3::new_xyz(-x_translation, -y_translation, 0.0));
         }
 
         model = scale(model, Vec3::new_xyz(self.width, self.height, 1.0));

--- a/koala_chess/src/board.rs
+++ b/koala_chess/src/board.rs
@@ -1,6 +1,7 @@
 use crate::{
     bitmap,
     mat4::Mat4,
+    projections::orthogonal_projection,
     shader::Shader,
     traits::Draw,
     transformations::{rotate_z, scale, translate},
@@ -165,26 +166,4 @@ impl Draw for Board {
 
         Ok(())
     }
-}
-
-// Right-handed, -1 to 1
-fn orthogonal_projection(
-    left: gl::types::GLfloat,
-    right: gl::types::GLfloat,
-    bottom: gl::types::GLfloat,
-    top: gl::types::GLfloat,
-    near: gl::types::GLfloat,
-    far: gl::types::GLfloat,
-) -> Mat4 {
-    let mut projection = Mat4::default();
-    projection[0][0] = 2.0 / (right - left);
-    projection[1][1] = 2.0 / (top - bottom);
-    projection[2][2] = -2.0 / (far - near);
-    projection[3][0] = -(right + left) / (right - left);
-    projection[3][1] = -(top + bottom) / (top - bottom);
-    projection[3][2] = -(far + near) / (far - near);
-
-    projection[3][3] = 1.0;
-
-    projection
 }

--- a/koala_chess/src/board.rs
+++ b/koala_chess/src/board.rs
@@ -21,6 +21,9 @@ pub struct Board {
 }
 
 impl Board {
+    pub const TEXTURE_SIZE: i32 = 2048;
+    pub const BORDER_TEXTURE_SIZE: i32 = 12;
+
     pub fn initialize(shader: Shader) {
         *SHADER
             .lock()
@@ -91,8 +94,8 @@ impl Board {
                 gl::TEXTURE_2D,
                 0,
                 gl::RGBA8 as gl::types::GLint,
-                2048,
-                2048,
+                Board::TEXTURE_SIZE,
+                Board::TEXTURE_SIZE,
                 0,
                 gl::BGRA_EXT,
                 gl::UNSIGNED_BYTE,

--- a/koala_chess/src/game.rs
+++ b/koala_chess/src/game.rs
@@ -1,20 +1,29 @@
 use crate::{
     board::Board,
     piece::{Piece, PieceColor, PieceKind},
+    projections::orthogonal_projection,
     shader,
-    traits::Draw,
 };
 use logger::*;
 use std::error::Error;
 
 pub struct Game {
+    pub aspect_ratio: f32,
+    pub world_width: f32,
+    pub world_height: f32,
     pub board: Board,
     pub pieces: Vec<Piece>,
 }
 
 impl Game {
     pub fn new() -> Game {
-        let board = Board;
+        let board = Board {
+            x: 0.0,
+            y: 0.0,
+            width: 620.0,
+            height: 620.0,
+            rotation: 0.0,
+        };
 
         let mut pieces: Vec<Piece> = Vec::new();
 
@@ -83,7 +92,13 @@ impl Game {
         pieces.push(white_king);
         pieces.push(black_king);
 
-        Game { board, pieces }
+        Game {
+            aspect_ratio: 0.0,
+            world_width: 800.0,
+            world_height: 800.0,
+            board,
+            pieces,
+        }
     }
 
     pub fn initialize() {
@@ -131,10 +146,8 @@ impl Game {
             gl::GenerateMipmap(gl::TEXTURE_2D);
         }
     }
-}
 
-impl Draw for Game {
-    fn draw(&self, aspect_ratio: f32) -> Result<(), Box<dyn Error>> {
+    pub fn draw(&mut self, aspect_ratio: f32) -> Result<(), Box<dyn Error>> {
         unsafe {
             // Set the clear color
             gl::ClearColor(0.17, 0.32, 0.59, 0.0);
@@ -143,12 +156,45 @@ impl Draw for Game {
             gl::Clear(gl::COLOR_BUFFER_BIT);
         }
 
+        self.aspect_ratio = aspect_ratio;
+        self.world_width = 800.0;
+        self.world_height = 800.0;
+
+        if self.aspect_ratio >= 1.0 {
+            self.world_width *= self.aspect_ratio;
+        } else {
+            self.world_height /= self.aspect_ratio;
+        }
+
+        // Calculate projection
+        let projection =
+            orthogonal_projection(0.0, self.world_width, self.world_height, 0.0, -1.0, 1.0);
+
+        // Center board
+        self.board.x = self.world_width / 2.0 - self.board.width / 2.0;
+        self.board.y = self.world_height / 2.0 - self.board.height / 2.0;
+
         // Draw board
-        self.board.draw(aspect_ratio)?;
+        self.board.draw(&projection)?;
 
         // Draw pieces
-        for piece in self.pieces.iter() {
-            piece.draw(aspect_ratio)?;
+        let ratio = self.board.width / 2048.0;
+        let piece_size = 253.0;
+        let border_size = 12.0;
+        let scaled_piece_size = piece_size * ratio;
+        let scaled_border_size = border_size * ratio;
+
+        for piece in self.pieces.iter_mut() {
+            piece.x = self.board.x
+                + scaled_border_size
+                + (piece.board_x as i8 - 7).abs() as f32 * scaled_piece_size;
+            piece.y = self.board.y
+                + scaled_border_size
+                + (piece.board_y as i8 - 7).abs() as f32 * scaled_piece_size;
+            piece.width = scaled_piece_size;
+            piece.height = scaled_piece_size;
+
+            piece.draw(&projection)?;
         }
 
         Ok(())

--- a/koala_chess/src/game.rs
+++ b/koala_chess/src/game.rs
@@ -178,11 +178,9 @@ impl Game {
         self.board.draw(&projection)?;
 
         // Draw pieces
-        let ratio = self.board.width / 2048.0;
-        let piece_size = 253.0;
-        let border_size = 12.0;
-        let scaled_piece_size = piece_size * ratio;
-        let scaled_border_size = border_size * ratio;
+        let ratio = self.board.width / Board::TEXTURE_SIZE as f32;
+        let scaled_piece_size = Piece::TEXTURE_SIZE as f32 * ratio;
+        let scaled_border_size = Board::BORDER_TEXTURE_SIZE as f32 * ratio;
 
         for piece in self.pieces.iter_mut() {
             piece.x = self.board.x

--- a/koala_chess/src/game.rs
+++ b/koala_chess/src/game.rs
@@ -174,6 +174,9 @@ impl Game {
         self.board.x = self.world_width / 2.0 - self.board.width / 2.0;
         self.board.y = self.world_height / 2.0 - self.board.height / 2.0;
 
+        // TODO: Remove temporary rotation
+        self.board.rotation = 45.0;
+
         // Draw board
         self.board.draw(&projection)?;
 
@@ -192,7 +195,7 @@ impl Game {
             piece.width = scaled_piece_size;
             piece.height = scaled_piece_size;
 
-            piece.draw(&projection)?;
+            piece.draw(&projection, &self.board)?;
         }
 
         Ok(())

--- a/koala_chess/src/main.rs
+++ b/koala_chess/src/main.rs
@@ -10,7 +10,6 @@ mod platform;
 mod projections;
 mod renderer;
 mod shader;
-mod traits;
 mod transformations;
 mod vec3;
 mod vec4;
@@ -24,10 +23,10 @@ fn main() {
 
     // Initialize the game
     Game::initialize();
-    let game = Game::new();
+    let mut game = Game::new();
 
     // Enter the game loop
-    platform::windows::r#loop(window, game);
+    platform::windows::r#loop(window, &mut game);
 }
 
 #[cfg(target_family = "unix")]
@@ -37,8 +36,8 @@ fn main() {
 
     // Initialize the game
     Game::initialize();
-    let game = Game::new();
+    let mut game = Game::new();
 
     // Enter the game loop
-    platform::unix::r#loop(display, window, game)
+    platform::unix::r#loop(display, window, &mut game)
 }

--- a/koala_chess/src/main.rs
+++ b/koala_chess/src/main.rs
@@ -7,6 +7,7 @@ mod game;
 mod mat4;
 mod piece;
 mod platform;
+mod projections;
 mod renderer;
 mod shader;
 mod traits;

--- a/koala_chess/src/piece.rs
+++ b/koala_chess/src/piece.rs
@@ -1,6 +1,7 @@
 use crate::{
     bitmap,
     mat4::Mat4,
+    projections::orthogonal_projection,
     shader::Shader,
     traits::Draw,
     transformations::{scale, translate},
@@ -222,26 +223,4 @@ impl Draw for Piece {
 
         Ok(())
     }
-}
-
-// Right-handed, -1 to 1
-fn orthogonal_projection(
-    left: gl::types::GLfloat,
-    right: gl::types::GLfloat,
-    bottom: gl::types::GLfloat,
-    top: gl::types::GLfloat,
-    near: gl::types::GLfloat,
-    far: gl::types::GLfloat,
-) -> Mat4 {
-    let mut projection = Mat4::default();
-    projection[0][0] = 2.0 / (right - left);
-    projection[1][1] = 2.0 / (top - bottom);
-    projection[2][2] = -2.0 / (far - near);
-    projection[3][0] = -(right + left) / (right - left);
-    projection[3][1] = -(top + bottom) / (top - bottom);
-    projection[3][2] = -(far + near) / (far - near);
-
-    projection[3][3] = 1.0;
-
-    projection
 }

--- a/koala_chess/src/piece.rs
+++ b/koala_chess/src/piece.rs
@@ -41,6 +41,9 @@ pub struct Piece {
 }
 
 impl Piece {
+    pub const TEXTURE_ATLAS_SIZE: i32 = 1024;
+    pub const TEXTURE_SIZE: i32 = 253;
+
     pub fn new(color: PieceColor, kind: PieceKind, board_x: u8, board_y: u8) -> Piece {
         let (piece_x, piece_y) = match (&color, &kind) {
             (PieceColor::White, PieceKind::Pawn) => (0, 2),
@@ -143,8 +146,8 @@ impl Piece {
                 gl::TEXTURE_2D,
                 0,
                 gl::RGBA8 as gl::types::GLint,
-                1024,
-                1024,
+                Piece::TEXTURE_ATLAS_SIZE,
+                Piece::TEXTURE_ATLAS_SIZE,
                 0,
                 gl::BGRA_EXT,
                 gl::UNSIGNED_BYTE,

--- a/koala_chess/src/platform/unix.rs
+++ b/koala_chess/src/platform/unix.rs
@@ -1,6 +1,5 @@
 use crate::game::Game;
 use crate::renderer::open_gl;
-use crate::traits::Draw;
 use logger::*;
 use std::lazy::SyncLazy;
 use std::os::raw::{c_int, c_uint};
@@ -284,7 +283,7 @@ pub fn create_window() -> (*mut xlib::Display, glx::types::Window) {
     }
 }
 
-pub fn r#loop(display: *mut xlib::Display, window: u64, game: Game) {
+pub fn r#loop(display: *mut xlib::Display, window: u64, game: &mut Game) {
     unsafe {
         let wm_protocols_str =
             CString::new("WM_PROTOCOLS").unwrap_or_else(|_| fatal!("Could not create CString!"));

--- a/koala_chess/src/platform/windows.rs
+++ b/koala_chess/src/platform/windows.rs
@@ -1,6 +1,5 @@
 use crate::game::Game;
 use crate::renderer::open_gl;
-use crate::traits::Draw;
 use logger::*;
 use std::ffi::{CString, OsStr};
 use std::io;
@@ -115,7 +114,7 @@ pub fn create_window() -> HWND {
     window
 }
 
-pub fn r#loop(window: HWND, game: Game) {
+pub fn r#loop(window: HWND, game: &mut Game) {
     let device_context = unsafe { GetDC(window) };
 
     // The frequency of the performance counter is fixed at system boot and is consistent across all processors

--- a/koala_chess/src/projections.rs
+++ b/koala_chess/src/projections.rs
@@ -1,0 +1,23 @@
+use crate::mat4::Mat4;
+
+// Right-handed, -1 to 1
+pub fn orthogonal_projection(
+    left: gl::types::GLfloat,
+    right: gl::types::GLfloat,
+    bottom: gl::types::GLfloat,
+    top: gl::types::GLfloat,
+    near: gl::types::GLfloat,
+    far: gl::types::GLfloat,
+) -> Mat4 {
+    let mut projection = Mat4::default();
+    projection[0][0] = 2.0 / (right - left);
+    projection[1][1] = 2.0 / (top - bottom);
+    projection[2][2] = -2.0 / (far - near);
+    projection[3][0] = -(right + left) / (right - left);
+    projection[3][1] = -(top + bottom) / (top - bottom);
+    projection[3][2] = -(far + near) / (far - near);
+
+    projection[3][3] = 1.0;
+
+    projection
+}

--- a/koala_chess/src/traits.rs
+++ b/koala_chess/src/traits.rs
@@ -1,5 +1,0 @@
-use std::error::Error;
-
-pub trait Draw {
-    fn draw(&self, aspect_ratio: f32) -> Result<(), Box<dyn Error>>;
-}

--- a/koala_chess/src/vec3.rs
+++ b/koala_chess/src/vec3.rs
@@ -49,11 +49,20 @@ impl Mul<gl::types::GLfloat> for Vec3 {
 }
 
 impl Vec3 {
-    pub fn new(value: gl::types::GLfloat) -> Vec3 {
+    pub fn _new(value: gl::types::GLfloat) -> Vec3 {
         let mut result = Vec3::default();
         result[0] = value;
         result[1] = value;
         result[2] = value;
+
+        result
+    }
+
+    pub fn new_xyz(x: gl::types::GLfloat, y: gl::types::GLfloat, z: gl::types::GLfloat) -> Vec3 {
+        let mut result = Vec3::default();
+        result[0] = x;
+        result[1] = y;
+        result[2] = z;
 
         result
     }


### PR DESCRIPTION
- We reworked the rendering flow
  - The logic for drawing the board and drawing the pieces is encapsulated
    - We just pass the board reference to the individual piece drawing
- We are able to rotate the board and pieces (based on the board rotation) now
- We updated the underlying dependencies
- We applied minor improvements and performed small cleanups