### PR TITLE
Add alternative context creation for windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,7 @@ dependencies = [
  "gl",
  "glx",
  "logger",
+ "wgl",
  "winapi",
  "x11",
 ]
@@ -132,6 +133,13 @@ name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wgl"
+version = "0.1.0"
+dependencies = [
+ "gl_generator",
+]
 
 [[package]]
 name = "winapi"

--- a/gl/Cargo.toml
+++ b/gl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "gl"
 version = "0.1.0"
 authors = ["Oliver Piorun <Oliver.Piorun@ruhr-uni-bochum.de>"]
-edition = "2018"
+edition = "2021"
 build = "build.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/glx/Cargo.toml
+++ b/glx/Cargo.toml
@@ -2,7 +2,7 @@
 name = "glx"
 version = "0.1.0"
 authors = ["Oliver Piorun <Oliver.Piorun@ruhr-uni-bochum.de>"]
-edition = "2018"
+edition = "2021"
 build = "build.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/glx/build.rs
+++ b/glx/build.rs
@@ -12,7 +12,9 @@ fn main() {
         (1, 4),
         Profile::Core,
         Fallbacks::All,
-        ["GLX_ARB_create_context"],
+        [
+            "GLX_ARB_create_context", // For glXCreateContextAttribsARB(...)
+        ],
     )
     .write_bindings(GlobalGenerator, &mut file)
     .unwrap_or_else(|e| panic!("Could not create bindings! ({})", e));

--- a/koala_chess/Cargo.toml
+++ b/koala_chess/Cargo.toml
@@ -11,6 +11,7 @@ gl = { path = "../gl" }
 logger = { path = "../logger" }
 
 [target.'cfg(windows)'.dependencies]
+wgl = { path = "../wgl" }
 winapi = { version = "0.3.9", features = ["winuser", "libloaderapi", "profileapi", "impl-default"] }
 
 [target.'cfg(unix)'.dependencies]

--- a/koala_chess/Cargo.toml
+++ b/koala_chess/Cargo.toml
@@ -2,7 +2,7 @@
 name = "koala_chess"
 version = "0.1.0"
 authors = ["Oliver Piorun <Oliver.Piorun@ruhr-uni-bochum.de>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/koala_chess/src/platform/unix.rs
+++ b/koala_chess/src/platform/unix.rs
@@ -430,7 +430,7 @@ unsafe fn is_extension_supported(
     );
 
     let query_extensions_string_cstring = CString::from_raw(query_extensions_string_raw as *mut i8);
-    let query_extension_string_str = query_extensions_string_cstring.to_str()?;
+    let query_extensions_string_str = query_extensions_string_cstring.to_str()?;
 
     Ok(query_extensions_string_str.contains(extension))
 }

--- a/koala_chess/src/platform/unix.rs
+++ b/koala_chess/src/platform/unix.rs
@@ -403,7 +403,7 @@ fn get_address(function_name: &str) -> *const std::ffi::c_void {
     let null_terminated_function_name = CString::new(function_name)
         .unwrap_or_else(|_| fatal!("Could not create CString! ({})", function_name));
 
-    // Get address
+    // Get address (via glXGetProcAddress)
     let address = unsafe {
         // Reference: https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glXGetProcAddress.xml
         glx::GetProcAddress(
@@ -412,7 +412,7 @@ fn get_address(function_name: &str) -> *const std::ffi::c_void {
     };
 
     if address.is_null() {
-        fatal!("Could not get address ({})!", function_name);
+        fatal!("Could not get address! ({})", function_name);
     }
 
     address as *const std::ffi::c_void
@@ -424,14 +424,13 @@ unsafe fn is_extension_supported(
     screen: glx::types::GLint,
 ) -> Result<bool, Box<dyn Error>> {
     // Reference: https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glXQueryExtensionsString.xml
-    let query_extension_string_raw = glx::QueryExtensionsString(
+    let query_extensions_string_raw = glx::QueryExtensionsString(
         display as *mut glx::types::Display, // dpy
         screen,                              // screen
     );
 
-    let query_extension_string_cstring =
-        std::ffi::CString::from_raw(query_extension_string_raw as *mut i8);
-    let query_extension_string_str = query_extension_string_cstring.to_str()?;
+    let query_extensions_string_cstring = CString::from_raw(query_extensions_string_raw as *mut i8);
+    let query_extension_string_str = query_extensions_string_cstring.to_str()?;
 
-    Ok(query_extension_string_str.contains(extension))
+    Ok(query_extensions_string_str.contains(extension))
 }

--- a/koala_chess/src/platform/windows.rs
+++ b/koala_chess/src/platform/windows.rs
@@ -391,8 +391,6 @@ unsafe fn is_extension_supported(extension: &str, hdc: HDC) -> Result<bool, Box<
     let extensions_string_cstring = CString::from_raw(extensions_string_raw as *mut i8);
     let extensions_string_str = extensions_string_cstring.to_str()?;
 
-    println!("{}", extensions_string_str);
-
     Ok(extensions_string_str.contains(extension))
 }
 

--- a/logger/Cargo.toml
+++ b/logger/Cargo.toml
@@ -2,7 +2,7 @@
 name = "logger"
 version = "0.1.0"
 authors = ["Oliver Piorun <Oliver.Piorun@ruhr-uni-bochum.de>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/wgl/Cargo.toml
+++ b/wgl/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "wgl"
+version = "0.1.0"
+authors = ["Oliver Piorun <Oliver.Piorun@ruhr-uni-bochum.de>"]
+edition = "2018"
+build = "build.rs"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[build-dependencies]
+gl_generator = "0.14.0"

--- a/wgl/Cargo.toml
+++ b/wgl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "wgl"
 version = "0.1.0"
 authors = ["Oliver Piorun <Oliver.Piorun@ruhr-uni-bochum.de>"]
-edition = "2018"
+edition = "2021"
 build = "build.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/wgl/build.rs
+++ b/wgl/build.rs
@@ -8,12 +8,13 @@ fn main() {
         .unwrap_or_else(|e| panic!("Could not create bindings.rs file! ({})", e));
 
     Registry::new(
-        Api::Gles2,
-        (3, 2),
+        Api::Wgl,
+        (1, 0),
         Profile::Core,
         Fallbacks::All,
         [
-            "GL_EXT_texture_format_BGRA8888", // For GL_BGRA_EXT
+            "WGL_ARB_create_context",    // For wglCreateContextAttribsARB(...)
+            "WGL_ARB_extensions_string", // For wglGetExtensionsStringARB(...)
         ],
     )
     .write_bindings(GlobalGenerator, &mut file)

--- a/wgl/src/lib.rs
+++ b/wgl/src/lib.rs
@@ -1,0 +1,2 @@
+#![allow(clippy::all)]
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));


### PR DESCRIPTION
- Adds an alternative context creation for windows
  - Via `wglCreateContextAttribsARB(...)`
  - Lets us request a specific OpenGL version context
- Adds a `wgl` crate
  - Provides `wgl` bindings just like the `glx` and `gl` crates which provide bindings for the respective domains
- Bumps rust edition to `2021`